### PR TITLE
Device passcode length update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.ecsp</groupId>
     <artifactId>device-activation</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>war</packaging>
 
     <name>device-activation</name>

--- a/src/main/java/org/eclipse/ecsp/auth/lib/util/DeviceActivationUtil.java
+++ b/src/main/java/org/eclipse/ecsp/auth/lib/util/DeviceActivationUtil.java
@@ -55,7 +55,7 @@ import java.security.SecureRandom;
 public class DeviceActivationUtil {
     private static final int MAX_LENGTH = 14;
     private static final int PREFIX = 2;
-    private static final int ALPHANUM_LENGTH = 64;
+    private static final int ALPHANUM_LENGTH = 50;
     private static final int VALUE_5 = 5;
     private static final int VALUE_8 = 8;
     private static final int VALUE_2 = 2;


### PR DESCRIPTION
Please refer to our [contributing docs](./CONTRIBUTING.md) for any questions on submitting a pull request.
Issues are required for both bug fixes and features.

Resolves #12  


----
### Describe behaviour before the change
During Device activation passcode is generated with length of 78bytes.

* 

### Describe behaviour after the change
Now During Device activation passcode is generated with length of 64 bytes.

* 

### Pull request checklist
- [x ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [ x] My code follows the code style of this project
- [ x] Tests for the changes have been added (for bug fixes / features)
- [x ] All new and existing tests passed.
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [ ] No

----

